### PR TITLE
fix: widen Other text input and scroll to first question

### DIFF
--- a/docs/plans/2026-03-06-fix-questionnaire-other-input-width-and-scroll-plan.md
+++ b/docs/plans/2026-03-06-fix-questionnaire-other-input-width-and-scroll-plan.md
@@ -1,0 +1,149 @@
+---
+title: "fix: Wider Other input and scroll to first question"
+type: fix
+date: 2026-03-06
+---
+
+# fix: Wider Other input and scroll to first question
+
+Two UI improvements to the questionnaire: make the "Other" text input match the
+width of option items, and scroll to the first question when AI responds instead
+of scrolling to the bottom.
+
+## Acceptance Criteria
+
+- [x] When "Other" is selected, the text input is the same width as the option items above it
+- [x] When the AI responds with questions, the view scrolls to the first question (the `#question-form` element)
+- [x] Scroll-to-question works for all three scroll triggers: question form submit, message form submit, and background auto-send response
+- [x] Both templates (`conversation.html` and `message_fragment.html`) are updated consistently
+
+## 1. Wider "Other" text input
+
+**Problem:** The `.other-input` is nested inside a `<div>` within the
+`.option-item` label, alongside the radio/checkbox. Because it's a flex child
+sibling to the radio button, it's narrower than the full option row width.
+
+**Current structure** (`message_fragment.html:31-39`, `conversation.html:60-68`):
+
+```html
+<label class="option-item other-option">
+  <input type="radio" ...>     <!-- takes ~16px + gap -->
+  <div>
+    <div class="option-label">Other</div>
+    <input type="text" class="other-input" ...>  <!-- 100% of this div, NOT the option-item -->
+  </div>
+</label>
+```
+
+**Solution:** Move the `<input type="text">` out of the `<label>` and place it
+after the `.options-list` div, as a direct child of `.question-group`. This way
+it naturally spans the full width of the question group, matching the option
+items.
+
+**New structure:**
+
+```html
+<div class="question-group">
+  ...
+  <div class="options-list">
+    ...
+    <label class="option-item other-option">
+      <input type="radio" name="q_0" value="__other__">
+      <div>
+        <div class="option-label">Other</div>
+      </div>
+    </label>
+  </div>
+  <input type="text" name="q_0_other" class="other-input" placeholder="Type your answer..." maxlength="500">
+</div>
+```
+
+### Files to change
+
+**`internal/server/templates/message_fragment.html`** — Move `<input type="text"
+class="other-input">` from inside the `.other-option` label to after the
+`.options-list` closing `</div>`, still inside `.question-group`.
+
+**`internal/server/templates/conversation.html`** — Same change in the
+`.LastQuestions` block (lines 60-68).
+
+**`internal/server/static/style.css`** — Update the CSS `:has()` selector from:
+
+```css
+.other-option:has(input:checked) .other-input {
+  display: block;
+}
+```
+
+to:
+
+```css
+.question-group:has(.other-option input:checked) > .other-input {
+  display: block;
+}
+```
+
+No other CSS changes needed — `.other-input` already has `width: 100%`.
+
+## 2. Scroll to first question
+
+**Problem:** All three scroll triggers use `scrollTop = scrollHeight`, which
+jumps to the bottom. When questions appear, the user may not see the first
+question.
+
+**Solution:** Add a `scrollConversation()` helper in `app.js` that checks for
+`#question-form`. If present, scroll to it with `scrollIntoView()`. Otherwise,
+scroll to bottom as before.
+
+### Files to change
+
+**`internal/server/static/app.js`** — Add helper function and call it from
+`htmx:afterSwap`:
+
+```javascript
+function scrollConversation() {
+  var c = document.getElementById('conversation');
+  var q = document.getElementById('question-form');
+  if (q) {
+    q.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  } else if (c) {
+    c.scrollTop = c.scrollHeight;
+  }
+}
+```
+
+Call `scrollConversation()` at the end of the `htmx:afterSwap` handler (after
+`renderMarkdown` and `updateMessageFormVisibility`).
+
+**`internal/server/templates/conversation.html`** (line 42) — Replace inline
+scroll in `hx-on::after-request`:
+
+```
+document.getElementById('conversation').scrollTop = document.getElementById('conversation').scrollHeight;
+```
+
+with:
+
+```
+if(typeof scrollConversation==='function')scrollConversation();
+```
+
+**`internal/server/templates/message_fragment.html`** (line 13) — Same
+replacement in `hx-on::after-request`.
+
+**`internal/server/templates/conversation.html`** (line 110) — Same replacement
+in the message form's `hx-on::after-request`.
+
+**`internal/server/handlers.go`** (line 582) — Replace `c.scrollTop=c.scrollHeight`
+in the inline script with `if(typeof scrollConversation==='function')scrollConversation();`.
+
+**Note:** `scrollConversation` must be a global function (defined on `window` or
+outside the IIFE), since it's called from inline `hx-on` attributes and inline
+`<script>` tags. Either expose it on `window` or move it outside the IIFE.
+
+## References
+
+- `internal/server/static/style.css:207-242` — option-item styles
+- `internal/server/static/style.css:618-639` — other-input styles
+- `internal/server/static/app.js:47-53` — updateMessageFormVisibility pattern
+- `internal/server/handlers.go:582` — inline scroll script

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -579,7 +579,7 @@ func (s *Server) handleRepoStatus(w http.ResponseWriter, r *http.Request) {
 			fmt.Fprint(w, `<div id="repo-status" style="display:none">`)
 			s.pages["message_fragment.html"].ExecuteTemplate(w, "message_fragment.html", fragment)
 			fmt.Fprint(w, `</div><script>`)
-			fmt.Fprint(w, `(function(){var s=document.getElementById('repo-status');var c=document.getElementById('conversation');while(s.firstChild){c.appendChild(s.firstChild);}s.remove();if(typeof renderMarkdown==='function')renderMarkdown();c.scrollTop=c.scrollHeight;var f=document.getElementById('message-form');if(f){f.querySelector('textarea').disabled=false;f.querySelector('button').disabled=false;}})();`)
+			fmt.Fprint(w, `(function(){var s=document.getElementById('repo-status');var c=document.getElementById('conversation');while(s.firstChild){c.appendChild(s.firstChild);}s.remove();if(typeof renderMarkdown==='function')renderMarkdown();if(typeof scrollConversation==='function')scrollConversation();else{c.scrollTop=c.scrollHeight;}var f=document.getElementById('message-form');if(f){f.querySelector('textarea').disabled=false;f.querySelector('button').disabled=false;}})();`)
 			fmt.Fprint(w, `</script>`)
 			return
 		}

--- a/internal/server/static/app.js
+++ b/internal/server/static/app.js
@@ -1,3 +1,14 @@
+// Scroll to first question if present, otherwise scroll to bottom
+function scrollConversation() {
+  var c = document.getElementById("conversation");
+  var q = document.getElementById("question-form");
+  if (q) {
+    q.scrollIntoView({ behavior: "smooth", block: "start" });
+  } else if (c) {
+    c.scrollTop = c.scrollHeight;
+  }
+}
+
 (function () {
   function renderMarkdown(root) {
     var bubbles = (root || document).querySelectorAll(
@@ -59,6 +70,7 @@
   document.addEventListener("htmx:afterSwap", function (e) {
     renderMarkdown(e.detail.target);
     updateMessageFormVisibility();
+    scrollConversation();
   });
 
   // Validate question forms before HTMX sends

--- a/internal/server/static/style.css
+++ b/internal/server/static/style.css
@@ -634,7 +634,7 @@ body:has(.conversation-wrapper) .header-inner {
   box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.1);
 }
 
-.other-option:has(input:checked) .other-input {
+.question-group:has(.other-option input:checked) > .other-input {
   display: block;
 }
 

--- a/internal/server/templates/conversation.html
+++ b/internal/server/templates/conversation.html
@@ -39,7 +39,7 @@
                 hx-target="#conversation"
                 hx-swap="beforeend"
                 hx-disabled-elt="find button"
-                hx-on::after-request="this.closest('.question-block').remove(); document.getElementById('message-form').style.display = ''; document.getElementById('conversation').scrollTop = document.getElementById('conversation').scrollHeight;">
+                hx-on::after-request="this.closest('.question-block').remove(); document.getElementById('message-form').style.display = ''; scrollConversation();">
             {{range $q := .LastQuestions}}
             <div class="question-group">
               {{if $q.Header}}<span class="question-header">{{$q.Header}}</span>{{end}}
@@ -63,10 +63,10 @@
                   {{end}}
                   <div>
                     <div class="option-label">Other</div>
-                    <input type="text" name="q_{{$q.Index}}_other" class="other-input" placeholder="Type your answer..." maxlength="500">
                   </div>
                 </label>
               </div>
+              <input type="text" name="q_{{$q.Index}}_other" class="other-input" placeholder="Type your answer..." maxlength="500">
             </div>
             {{end}}
             <div class="mt-4" style="display:flex;gap:var(--space-3);">
@@ -107,7 +107,7 @@
               hx-target="#conversation"
               hx-swap="beforeend"
               hx-disabled-elt="find button, find textarea"
-              hx-on::after-request="this.reset(); document.getElementById('conversation').scrollTop = document.getElementById('conversation').scrollHeight;">
+              hx-on::after-request="this.reset(); scrollConversation();">
           <textarea name="message" placeholder="Describe the feature you'd like..." rows="2" required></textarea>
           <button type="submit" class="btn btn-primary">Send</button>
           <div class="htmx-indicator"><div class="spinner"></div></div>

--- a/internal/server/templates/message_fragment.html
+++ b/internal/server/templates/message_fragment.html
@@ -10,7 +10,7 @@
         hx-target="#conversation"
         hx-swap="beforeend"
         hx-disabled-elt="find button"
-        hx-on::after-request="this.closest('.question-block').remove(); document.getElementById('message-form').style.display = ''; document.getElementById('conversation').scrollTop = document.getElementById('conversation').scrollHeight;">
+        hx-on::after-request="this.closest('.question-block').remove(); document.getElementById('message-form').style.display = ''; scrollConversation();">
     {{range $q := .Questions}}
     <div class="question-group">
       {{if $q.Header}}<span class="question-header">{{$q.Header}}</span>{{end}}
@@ -34,10 +34,10 @@
           {{end}}
           <div>
             <div class="option-label">Other</div>
-            <input type="text" name="q_{{$q.Index}}_other" class="other-input" placeholder="Type your answer..." maxlength="500">
           </div>
         </label>
       </div>
+      <input type="text" name="q_{{$q.Index}}_other" class="other-input" placeholder="Type your answer..." maxlength="500">
     </div>
     {{end}}
     <div class="mt-4">


### PR DESCRIPTION
Closes #19

## Summary
- Move the "Other" text input outside the option label so it spans the full width of option items, matching the visual consistency of the questionnaire
- Add `scrollConversation()` helper that scrolls to the first question when AI responds, instead of jumping to the bottom of the conversation
- Updated all 4 scroll triggers (question form submit, message form submit, background auto-send, htmx:afterSwap)

## Testing
- Verify "Other" text input width matches option items when selected
- Verify selecting "Other" still shows/hides the text input correctly
- Verify form validation still requires text when "Other" is selected
- Verify scroll behavior targets first question on all response types
- Verify scroll still goes to bottom when no questions are present

## Post-Deploy Monitoring & Validation
No additional operational monitoring required: CSS/JS-only UI changes with no server-side behavior change.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)