### PR TITLE
feat: Enter key sends message, Shift+Enter adds new line

### DIFF
--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -325,7 +325,7 @@ func (s *Server) handleSendMessage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	userMessage := r.FormValue("message")
+	userMessage := strings.TrimSpace(r.FormValue("message"))
 	// If no direct message, try assembling from multi-question form fields
 	if userMessage == "" {
 		userMessage = assembleQuestionAnswers(r)

--- a/internal/server/static/app.js
+++ b/internal/server/static/app.js
@@ -111,4 +111,32 @@ setInterval(updateElapsedTimers, 1000);
       }
     }
   });
+
+  // Enter-to-send: submit chat form on Enter, newline on Shift+Enter
+  document.addEventListener("keydown", function (e) {
+    if (e.key !== "Enter") return;
+    var textarea = e.target;
+    if (!textarea.matches(".chat-form textarea")) return;
+
+    // Allow Shift+Enter to insert newline (default behavior)
+    if (e.shiftKey) return;
+
+    // Don't submit during IME composition (CJK input)
+    if (e.isComposing || e.keyCode === 229) return;
+
+    e.preventDefault();
+
+    // Don't submit empty/whitespace-only messages
+    if (textarea.value.trim() === "") return;
+
+    // Don't submit if textarea is disabled (processing in progress)
+    if (textarea.disabled) return;
+
+    // Submit via the form's submit button to keep HTMX pipeline intact
+    var form = textarea.closest("form");
+    if (form) {
+      var btn = form.querySelector('button[type="submit"]');
+      if (btn && !btn.disabled) btn.click();
+    }
+  });
 })();

--- a/internal/server/templates/conversation.html
+++ b/internal/server/templates/conversation.html
@@ -154,7 +154,7 @@
               hx-swap="beforeend"
               hx-disabled-elt="find button, find textarea"
               hx-on::after-request="this.reset(); scrollConversation();">
-          <textarea name="message" placeholder="Describe the feature you'd like..." rows="2" required></textarea>
+          <textarea name="message" placeholder="Describe the feature you'd like... (Enter to send, Shift+Enter for new line)" rows="2" required></textarea>
           <button type="submit" class="btn btn-primary">Send</button>
           <div class="htmx-indicator"><div class="spinner"></div></div>
         </form>


### PR DESCRIPTION
## Summary
- **Enter** submits the message (same as clicking Send), **Shift+Enter** inserts a new line
- IME composition guard prevents accidental submission during CJK input
- Whitespace-only messages blocked both client-side and server-side
- Placeholder hint updated to show keyboard shortcuts

## Changes
- `internal/server/static/app.js` — delegated `keydown` listener on `.chat-form textarea`
- `internal/server/templates/conversation.html` — placeholder text updated
- `internal/server/handlers.go` — `strings.TrimSpace()` on message input

## Test plan
- [ ] Type a message and press Enter — should submit
- [ ] Press Shift+Enter — should insert new line
- [ ] Press Enter with empty/whitespace textarea — should not submit
- [ ] Click Send button — should still work as before
- [ ] Verify placeholder text shows keyboard hint
- [ ] Test with IME input (if available) — Enter during composition should not submit

## Post-Deploy Monitoring & Validation
No additional operational monitoring required: client-side keyboard behavior change with minimal server-side validation tweak (TrimSpace).

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)