### PR TITLE
fix: Remove gap between left sidebar and chat on conversation page

### DIFF
--- a/docs/plans/2026-03-08-fix-conversation-sidebar-chat-gap-plan.md
+++ b/docs/plans/2026-03-08-fix-conversation-sidebar-chat-gap-plan.md
@@ -1,0 +1,67 @@
+---
+title: "fix: Remove gap between left sidebar and chat on conversation page"
+type: fix
+date: 2026-03-08
+issue: https://github.com/esnunes/prompter/issues/41
+---
+
+# fix: Remove gap between left sidebar and chat on conversation page
+
+On the conversation page, there is an unwanted visual gap between the left sidebar (prompt list) and the chat content area. The chat content should sit flush against the left sidebar border.
+
+## Root Cause
+
+In `internal/server/static/style.css`, the `.container` class applies `padding: var(--space-6) var(--space-6)` to all pages (line 72). The conversation page override at line 406 removes top, bottom, and right padding — but **omits `padding-left`**:
+
+```css
+/* Current (line 406-410) */
+.container:has(.conversation-wrapper) {
+  padding-top: 0;
+  padding-bottom: 0;
+  padding-right: 0;
+  /* padding-left is missing — this causes the gap */
+}
+```
+
+## Fix
+
+Add `padding-left: 0` to the existing conversation container rule:
+
+```css
+/* internal/server/static/style.css:406 */
+.container:has(.conversation-wrapper) {
+  padding-top: 0;
+  padding-bottom: 0;
+  padding-right: 0;
+  padding-left: 0;
+}
+```
+
+Or simplify to:
+
+```css
+.container:has(.conversation-wrapper) {
+  padding: 0;
+}
+```
+
+## Acceptance Criteria
+
+- [x] Chat content sits flush against the left sidebar border on the conversation page
+- [x] Dashboard page keeps its current padding (`var(--space-6)`)
+- [x] Repo page keeps its current padding (`var(--space-6)`)
+- [x] Right side (chat to revision sidebar) remains unchanged
+- [x] Mobile layout (<=768px) is unaffected (sidebar is hidden)
+
+## Why This Is Safe
+
+- **Scoped selector**: `.container:has(.conversation-wrapper)` only matches the conversation page
+- **Internal padding preserved**: `.chat-messages` has its own `padding: var(--space-6) var(--space-4)`, so message readability is unaffected
+- **Chat input preserved**: `.chat-input` has its own `padding: var(--space-4) var(--space-4)`
+- **Archive banner preserved**: Inside `.conversation-main`, unaffected by container padding
+- **Mobile unaffected**: `.prompt-sidebar` is `display: none` at <=768px
+
+## References
+
+- Issue: [#41](https://github.com/esnunes/prompter/issues/41)
+- File: `internal/server/static/style.css:406-410`

--- a/internal/server/static/style.css
+++ b/internal/server/static/style.css
@@ -404,9 +404,7 @@ label {
 
 /* Two-column conversation layout */
 .container:has(.conversation-wrapper) {
-  padding-top: 0;
-  padding-bottom: 0;
-  padding-right: 0;
+  padding: 0;
 }
 
 .conversation-wrapper {


### PR DESCRIPTION
## Summary
- Removes the unwanted visual gap between the left sidebar and chat content area on the conversation page
- Simplifies `.container:has(.conversation-wrapper)` from three individual padding overrides to `padding: 0`
- Only affects the conversation page — dashboard and repo pages keep their current spacing

Closes #41

## Testing
- Verified `.conversation-wrapper` only exists in `conversation.html` — other pages unaffected
- Chat messages retain their own internal padding (`var(--space-6) var(--space-4)`)
- Chat input retains its own padding (`var(--space-4)`)
- Mobile layout unaffected (sidebar hidden at <=768px)

## Post-Deploy Monitoring & Validation
No additional operational monitoring required: CSS-only change scoped to conversation page layout.

---

[![Compound Engineered](https://img.shields.io/badge/Compound-Engineered-6366f1)](https://github.com/EveryInc/compound-engineering-plugin) 🤖 Generated with [Claude Code](https://claude.com/claude-code)