### PR TITLE
feat: Show repository list on dashboard instead of prompt requests

### DIFF
--- a/docs/plans/2026-03-08-feat-dashboard-repository-list-plan.md
+++ b/docs/plans/2026-03-08-feat-dashboard-repository-list-plan.md
@@ -1,0 +1,113 @@
+---
+title: "Dashboard: Show repository list instead of prompt requests"
+type: feat
+date: 2026-03-08
+issue: https://github.com/esnunes/prompter/issues/42
+---
+
+# Dashboard: Show repository list instead of prompt requests
+
+## Overview
+
+Replace the dashboard main content area with a list of repositories ordered by most recent activity, instead of the current flat grid of prompt request cards. Users see all their repos at a glance and navigate into the one they want, while the sidebar retains quick access to individual prompts.
+
+## Acceptance Criteria
+
+- [x] Dashboard main content shows repositories, not prompt request cards
+- [x] Each repository entry displays its URL (e.g. `github.com/owner/repo`)
+- [x] Each repository entry shows the count of active (non-archived) prompt requests and last activity date
+- [x] Repositories ordered by most recent `prompt_requests.updated_at` (DESC)
+- [x] Clicking a repository navigates to `/github.com/{org}/{repo}/prompt-requests`
+- [x] "Go to repository" URL input form remains as-is
+- [x] "Show archived" toggle removed from dashboard
+- [x] Left sidebar unchanged (shows all prompts across all repos)
+- [x] Empty state updated: "No repositories yet. Enter a repository URL above to get started."
+- [x] Only repositories with at least one non-deleted prompt request appear
+
+## Technical Approach
+
+### Design Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| "Activity" metric | `MAX(prompt_requests.updated_at)` | Simpler than joining through messages; `updated_at` is touched on title, status, and issue changes |
+| Include archived in activity calc | Yes | Archiving is a recent action; excluding it could hide recently-active repos |
+| Exclude deleted PRs | Yes | Deleted PRs are logically gone |
+| Show repos with zero non-deleted PRs | No | Avoids ghost entries; repos only exist in DB when a PR is created |
+| Repo entry metadata | URL + active PR count + last activity date | Provides enough scannability without clutter |
+| Clickable element | Reuse `.card` / `.card-link` pattern | Consistent with existing UI; avoids nested `<a>` issues (see learnings) |
+
+### Gotcha: Nested Anchor Tags
+
+Per `docs/solutions/ui-bugs/nested-anchor-tags-duplicate-rendering.md`, avoid nesting `<a>` elements inside clickable cards. The new repo cards should use a single `<a>` wrapping the entire card with no inner anchors.
+
+## MVP
+
+### 1. New model: `RepositorySummary` (`internal/models/models.go`)
+
+Add a lightweight struct for the dashboard query result:
+
+```go
+type RepositorySummary struct {
+    ID            int64
+    URL           string
+    ActivePRCount int
+    LastActivity  time.Time
+}
+```
+
+### 2. New query: `ListRepositorySummaries` (`internal/db/queries.go`)
+
+```sql
+SELECT r.id, r.url,
+       COUNT(CASE WHEN pr.archived = 0 THEN 1 END) as active_pr_count,
+       MAX(pr.updated_at) as last_activity
+FROM repositories r
+JOIN prompt_requests pr ON pr.repository_id = r.id
+WHERE pr.status != 'deleted'
+GROUP BY r.id
+ORDER BY last_activity DESC
+```
+
+Returns `[]models.RepositorySummary`. The `JOIN` ensures repos with zero non-deleted PRs are excluded. The `COUNT(CASE ...)` counts only active (non-archived) PRs for the display count.
+
+### 3. Update handler: `handleDashboard` (`internal/server/handlers.go:53`)
+
+- Replace `dashboardData` struct:
+  - Remove `PromptRequests []models.PromptRequest` and `ShowArchived bool`
+  - Add `Repositories []models.RepositorySummary`
+- Remove `showArchived` query param logic
+- Call `ListRepositorySummaries()` instead of `ListPromptRequests()`
+- Simplify sidebar fetch: always call `ListPromptRequests(false)` (remove the conditional branch)
+
+### 4. Update template: `dashboard.html` (`internal/server/templates/dashboard.html`)
+
+- Remove the archive toggle (lines 6-10)
+- Remove the `{{range .PromptRequests}}` card loop and archive action markup
+- Add a `{{range .Repositories}}` loop rendering repo cards:
+  - `<a href="/{{.URL}}/prompt-requests" class="card card-link">`
+  - Repo URL as card title
+  - Meta line: `{{.ActivePRCount}} prompt requests` + `Last activity: {{.LastActivity.Format "Jan 2, 2006"}}`
+- Update empty state text to "No repositories yet"
+- Keep "Go to repository" form untouched
+
+### 5. Clean up dead code
+
+- Remove `ShowArchived` from `dashboardData` struct
+- The `?archived=1` query param is no longer handled on the dashboard route
+
+## File Change Summary
+
+| File | Change |
+|------|--------|
+| `internal/models/models.go` | Add `RepositorySummary` struct |
+| `internal/db/queries.go` | Add `ListRepositorySummaries()` query function |
+| `internal/server/handlers.go` | Update `dashboardData` struct and `handleDashboard()` |
+| `internal/server/templates/dashboard.html` | Replace card loop with repo list, remove archive toggle |
+
+## References
+
+- Issue: https://github.com/esnunes/prompter/issues/42
+- Nested anchor gotcha: `docs/solutions/ui-bugs/nested-anchor-tags-duplicate-rendering.md`
+- Existing repo page pattern: `internal/server/templates/repo.html`
+- Original repo-centric design: `docs/brainstorms/2026-02-17-repo-centric-restructure-brainstorm.md`

--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -40,6 +40,34 @@ func (q *Queries) ListRepositories() ([]models.Repository, error) {
 	return results, rows.Err()
 }
 
+func (q *Queries) ListRepositorySummaries() ([]models.RepositorySummary, error) {
+	rows, err := q.db.Query(`
+		SELECT r.id, r.url,
+		       COUNT(CASE WHEN pr.archived = 0 THEN 1 END) as active_pr_count,
+		       MAX(pr.updated_at) as last_activity
+		FROM repositories r
+		JOIN prompt_requests pr ON pr.repository_id = r.id
+		WHERE pr.status != 'deleted'
+		GROUP BY r.id
+		ORDER BY last_activity DESC`)
+	if err != nil {
+		return nil, fmt.Errorf("listing repository summaries: %w", err)
+	}
+	defer rows.Close()
+
+	var results []models.RepositorySummary
+	for rows.Next() {
+		var rs models.RepositorySummary
+		var lastActivity string
+		if err := rows.Scan(&rs.ID, &rs.URL, &rs.ActivePRCount, &lastActivity); err != nil {
+			return nil, fmt.Errorf("scanning repository summary: %w", err)
+		}
+		rs.LastActivity, _ = time.Parse(time.DateTime, lastActivity)
+		results = append(results, rs)
+	}
+	return results, rows.Err()
+}
+
 func (q *Queries) UpsertRepository(url, localPath string) (*models.Repository, error) {
 	_, err := q.db.Exec(
 		`INSERT INTO repositories (url, local_path) VALUES (?, ?)

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -33,6 +33,13 @@ type PromptRequest struct {
 	LatestAssistantAt *time.Time
 }
 
+type RepositorySummary struct {
+	ID            int64
+	URL           string
+	ActivePRCount int
+	LastActivity  time.Time
+}
+
 type Message struct {
 	ID              int64
 	PromptRequestID int64

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -46,28 +46,21 @@ type basePageData struct {
 
 type dashboardData struct {
 	basePageData
-	PromptRequests []models.PromptRequest
-	ShowArchived   bool
+	Repositories []models.RepositorySummary
 }
 
 func (s *Server) handleDashboard(w http.ResponseWriter, r *http.Request) {
-	showArchived := r.URL.Query().Get("archived") == "1"
-	prs, err := s.queries.ListPromptRequests(showArchived)
+	repos, err := s.queries.ListRepositorySummaries()
 	if err != nil {
-		log.Printf("listing prompt requests: %v", err)
+		log.Printf("listing repository summaries: %v", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
 	}
-	// Sidebar always gets active prompts
-	sidebarPRs := prs
-	if showArchived {
-		sidebarPRs, _ = s.queries.ListPromptRequests(false)
-	}
+	sidebarPRs, _ := s.queries.ListPromptRequests(false)
 	sidebar := s.buildSidebar(sidebarPRs, "all", 0)
 	s.renderPage(w, "dashboard.html", dashboardData{
-		basePageData:   basePageData{Sidebar: sidebar},
-		PromptRequests: prs,
-		ShowArchived:   showArchived,
+		basePageData: basePageData{Sidebar: sidebar},
+		Repositories: repos,
 	})
 }
 

--- a/internal/server/templates/dashboard.html
+++ b/internal/server/templates/dashboard.html
@@ -3,11 +3,6 @@
 {{define "content"}}
 <div class="dashboard-header">
   <h2>Dashboard</h2>
-  <label class="archive-toggle">
-    <input type="checkbox" {{if .ShowArchived}}checked{{end}}
-           onchange="window.location.href = this.checked ? '/?archived=1' : '/'">
-    Show archived
-  </label>
 </div>
 
 <div class="card mb-4">
@@ -20,50 +15,21 @@
   </form>
 </div>
 
-{{if .PromptRequests}}
-<h3 class="mb-4">{{if .ShowArchived}}Archived prompt requests{{else}}Your prompt requests{{end}}</h3>
-{{range .PromptRequests}}
-<a href="/{{.RepoURL}}/prompt-requests/{{.ID}}" class="card card-link">
-  <div class="pr-title">
-    {{if .Title}}{{.Title}}{{else}}Untitled{{end}}
-    <span class="badge {{if eq .Status "published"}}badge-published{{else}}badge-draft{{end}}">{{.Status}}</span>
-  </div>
-  <div class="pr-repo"><span class="pr-repo-link" onclick="event.preventDefault(); event.stopPropagation(); window.location.href='/{{.RepoURL}}/prompt-requests';">{{.RepoURL}}</span></div>
+{{if .Repositories}}
+<h3 class="mb-4">Your repositories</h3>
+{{range .Repositories}}
+<a href="/{{.URL}}/prompt-requests" class="card card-link">
+  <div class="pr-title">{{.URL}}</div>
   <div class="pr-meta">
-    <span>{{.MessageCount}} messages</span>
-    {{if gt .RevisionCount 0}}<span>{{.RevisionCount}} revisions</span>{{end}}
-    <span>{{.CreatedAt.Format "Jan 2, 2006"}}</span>
+    <span>{{.ActivePRCount}} prompt requests</span>
+    <span>Last activity: {{.LastActivity.Format "Jan 2, 2006"}}</span>
   </div>
-  {{if $.ShowArchived}}
-  <span class="card-action" role="button" tabindex="0"
-        aria-label="Unarchive prompt"
-        onclick="event.preventDefault(); event.stopPropagation(); fetch('/{{.RepoURL}}/prompt-requests/{{.ID}}/unarchive', {method:'POST'}).then(function(){location.reload()});"
-        onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();this.click();}">
-    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-      <path d="M2 5h12v8a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1V5z"/><path d="M8 11V7"/><path d="M6 9l2-2 2 2"/>
-    </svg>
-  </span>
-  {{else}}
-  <span class="card-action" role="button" tabindex="0"
-        aria-label="Archive prompt"
-        onclick="event.preventDefault(); event.stopPropagation(); var msg='Archive this prompt request?'; {{if .IssueURL}}msg+=' The linked GitHub issue will remain open.';{{end}} if(confirm(msg)){fetch('/{{.RepoURL}}/prompt-requests/{{.ID}}/archive', {method:'POST'}).then(function(){location.reload()});}"
-        onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();this.click();}">
-    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-      <path d="M2 5h12v8a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1V5z"/><path d="M8 7v4"/><path d="M6 9l2 2 2-2"/>
-    </svg>
-  </span>
-  {{end}}
 </a>
 {{end}}
 {{else}}
 <div class="empty-state">
-  {{if .ShowArchived}}
-  <h2>No archived prompt requests</h2>
-  <p>You haven't archived any prompt requests yet.</p>
-  {{else}}
-  <h2>No prompt requests yet</h2>
+  <h2>No repositories yet</h2>
   <p>Enter a repository URL above to get started.</p>
-  {{end}}
 </div>
 {{end}}
 {{end}}


### PR DESCRIPTION
## Summary
- Replaces the flat grid of prompt request cards on the dashboard with a repository list
- Each repo entry shows URL, active prompt request count, and last activity date
- Repos ordered by most recent `prompt_requests.updated_at` (DESC)
- Removes the "Show archived" toggle from dashboard (repo page toggle unchanged)
- Keeps "Go to repository" input form and sidebar behavior as-is

Closes #42

## Changes
| File | Change |
|------|--------|
| `internal/models/models.go` | Add `RepositorySummary` struct |
| `internal/db/queries.go` | Add `ListRepositorySummaries()` query |
| `internal/server/handlers.go` | Simplify `dashboardData` and `handleDashboard()` |
| `internal/server/templates/dashboard.html` | Replace card loop with repo list, remove archive toggle |

## Testing
- Build passes (`go build ./...`)
- Manual verification: dashboard shows repos ordered by activity, clicking navigates to repo page, sidebar unchanged

## Post-Deploy Monitoring & Validation
No additional operational monitoring required: UI-only change affecting the dashboard view with no new external dependencies or data mutations.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)